### PR TITLE
Update people page HTML and fix projects navbar

### DIFF
--- a/people/index.html
+++ b/people/index.html
@@ -23,12 +23,11 @@
 
   <main class="people">
     <article class="leaders" role="contentinfo" aria-label="Leaders of the lab">
+      <h1>Principal Investigator</h1>
       <div class="people-group">
-       
 
         <section class="textblock top_dog">
           <h2>Marcelo Worsley</h2>
-          <h3>Principal Investigator</h3>
           <img class="lazy" data-src="../assets/img/people/marcelo-worsley copy.jpg" alt="">
           <p>I am an associate professor of Learning Sciences and Computer Science at Northwestern's School of Education and Social Policy and the McCormick School of Engineering. My research aims to advance society's understanding of how students learn in complex learning environments by forging new opportunities for using multimodal technology.</p>
           <a href="http://marceloworsley.com/" target="_blank" rel="noreferrer" aria-label="Marcelo's Website">website</a>
@@ -117,7 +116,7 @@
         </section>
 
         <section class="textblock">
-          <h2>Victoria Concepción Chavez</h2>
+          <h2>Victoria C. Chavez</h2>
           <img class="lazy" data-src="../assets/img/people/victoria.jpg" alt="">
           <p>Victoria (V/they/she) is a Chicago-born and raised Chapine (Guatemalan) educator, scholar, and engineer. Currently, they’re a third-year PhD student at Northwestern University's Computer Science Program. Victoria’s research interests explore systemic issues within computer science education, centering the experiences of Black, Disabled, Indigenous, and Latine/x students. Most recently, their research has focused on teaching and learning accessibility as well as unpacking how ableism is codified in the policies, practices, and pedagogies used in college CS courses.</p>
           <a href="https://vickiebananas.com/" target="_blank">website</a>
@@ -149,7 +148,7 @@
       <div class="people-group">
 
         <section class="textblock">
-          <h2>Kidus Chernet Tessma</h2>
+          <h2>Kidus Tessma</h2>
           <img class="lazy" data-src="../assets/img/people/kidus-tessma.jpg" alt="">
           <p>Kidus Chernet Tessma is a junior studying Computer Science and Mathematics. I am working on the SportSense Team in redesigning the FAAM website.</p>
           <!-- <a href="#" target="_blank">website</a> -->
@@ -259,106 +258,102 @@
     </article>
     <article class="alumni" role="contentinfo" aria-label="Alumni of the lab">
       <h1>Alumni</h1>
+
+      <h2>PhD Alumni</h2>
       <div class="list-group">
-      <ul>
-        <a href="https://www.visheshk.net/" target="_blank">
-          Vishesh Kumar
-        </a>
-        <li>
-          JaCoya Thompson, PhD  
-        </li>
-        <li>DJ (Stephanie T. Jones, PhD)</li>
-        <li>Nicole Tartakovsky</li>
-        <a href="https://ethanpinedaa.dev/" target="_blank">
-          Ethan Piñeda  
-        </a>
-        <li>Siddhartha Saha</li>
-        <li>Lucas Zurbuchen</li>
-        <li>Sara Bouftas</li>
-        <a href="https://www.linkedin.com/in/justin-aronson/" target="_blank">
-          Justin Aronson  
-        </a>
-        <a href="https://sites.northwestern.edu/adiawallace/" target="_blank">
-           Adia Wallace
-        </a>
-        <li>Marco Wang</li>
-        <li>Danny Pineda</li>
-        <li>John Sanchez</li>
-        <li>Ethan M. Chan</li>
-        <li>Timothy Fu</li>
-        <li>Naomi Wu</li>
-        <li>David Bar-El, PhD</li>
-        <li> Emily Q. Wang, PhD </li>
-        <li>Connor Bain, PhD</li>
-        <li>Kit Martin, PhD</li>
-        <li>Yamini Ulaganathan</li>
-        <li>Vedant Apte</li>
-        <a href="https://www.afreenbhumgara.me/" target="_blank">
-          Afreen Bhumgara
-        </a>
-        <li>Joy Hsu</li>
-        <li>Saahas Parise</li>
-        <li>Tyler Nanoff</li>
-        <li>Antonio Rocha</li>
-        <li>Sengdao Inthavong</li>
-        <li> Kevin Mendoza</li>
-        <li> Sydney Simmons </li>
-        <li> Marc Jiang</li>
-        <li> Beck Mallwitz </li>
-        <li>Nathaniel Hardy</li>
-        <li> Seth May </li>
-        <li> Priya Kini </li>
-        <li> Mitchell Zhen</li>
-        <li> Jeremy Libretti-River </li>
-        <li>Alexander Redding</li>
-        <li>Justin Jia</li>
-        <li>Julie Park</li>
-        <li>Sophie Rollins</li>
-        <li>Andy Ko</li>
-        <li>Kelia Human</li>
-        <li>JooYoung Jang</li>
-        <li>Neil Vakharia</li>
-        <li>Harrison Pearl</li>
-        <li>Andy Moran</li>
-        <li>Judy Lee</li>
-        <li>Jordan Nishina</li>
-        <li>Aimee van der Berg</li>
-        <li>Alex Gist</li>
-        <li>Sam Arrants</li>
-        <li>Kya Suzuki</li>
-        <li>Elana Stettin</li>
-        <li>Shankar Salawan</li>
-        <li>Deniz Sagnalakar</li>
-        <li>Gabe Rojas-Westall</li>
-        <li>Nathan Summer Reiff</li>
-        <li>Melissa Escamilla Perez</li>
-        <li>Timothy Mwiti</li>
-        <li>Eric Mertz</li>
-        <li>Tom Large</li>
-        <li>Edward Kang</li>
-        <li>Durell Gill</li>
-        <li>Kira Furuichi</li>
-        <li>Simeon Charles</li>
-        <li>Bobbie Burgess</li>
-        <li>Aaron Karp</li>
-        <li>Audrey DeBruine</li>
-        <li>Avi Vaid</li>
-        <li>Caroline DeMarco</li>
-        <li>Emily Blackman</li>
-        <li>Haley De Boom</li>
-        <li>Jaiveer Kothari</li>
-        <li>Jimmy Song</li>
-        <li>Joonyong Rhee</li>
-        <li>Lindsay Rawitscher</li>
-        <li>Michael Chen</li>
-        <li>Robert Bell</li>
-        <li>Sebastian Perez</li>
-        <li>Aryan Mahajan</li>
-        <li>Siddharth Sheth</li>
-        <li>Stephenie Liew</li>
-        <li>Zoe Lewis</li>
-      </ul>
-    </div>
+        <ul>
+          <li>Connor Bain</li>
+          <li>David Bar-El</li>
+          <li>DJ (Stephanie T. Jones)</li>
+          <li>Kit Martin</li>
+          <li>JaCoya Thompson</li>
+          <li>Emily Q. Wang</li>
+        </ul>
+      </div>
+
+      <h2>Other Alumni</h2>
+      <div class="list-group">
+        <ul>
+          <li>Aaron Karp</li>
+          <li><a href="https://sites.northwestern.edu/adiawallace/" target="_blank">Adia Wallace</a></li>
+          <li><a href="https://www.afreenbhumgara.me/" target="_blank">Afreen Bhumgara</a></li>
+          <li>Aimee van der Berg</li>
+          <li>Alex Gist</li>
+          <li>Alexander Redding</li>
+          <li>Andy Ko</li>
+          <li>Andy Moran</li>
+          <li>Antonio Rocha</li>
+          <li>Aryan Mahajan</li>
+          <li>Audrey DeBruine</li>
+          <li>Avi Vaid</li>
+          <li>Beck Mallwitz</li>
+          <li>Bobbie Burgess</li>
+          <li>Caroline DeMarco</li>
+          <li>Danny Pineda</li>
+          <li>Deniz Sagnalakar</li>
+          <li>Durell Gill</li>
+          <li>Edward Kang</li>
+          <li>Elana Stettin</li>
+          <li>Emily Blackman</li>
+          <li>Eric Mertz</li>
+          <li>Ethan M. Chan</li>
+          <li><a href="https://ethanpinedaa.dev/" target="_blank">Ethan Piñeda</a></li>
+          <li>Gabe Rojas-Westall</li>
+          <li>Haley De Boom</li>
+          <li>Harrison Pearl</li>
+          <li>Jaiveer Kothari</li>
+          <li>Jeremy Libretti-River</li>
+          <li>Jimmy Song</li>
+          <li>John Sanchez</li>
+          <li>JooYoung Jang</li>
+          <li>Joonyong Rhee</li>
+          <li>Jordan Nishina</li>
+          <li>Joy Hsu</li>
+          <li>Judy Lee</li>
+          <li>Julie Park</li>
+          <li><a href="https://www.linkedin.com/in/justin-aronson/" target="_blank">Justin Aronson</a></li>
+          <li>Justin Jia</li>
+          <li>Kelia Human</li>
+          <li>Kevin Mendoza</li>
+          <li>Kira Furuichi</li>
+          <li>Kya Suzuki</li>
+          <li>Lindsay Rawitscher</li>
+          <li>Lucas Zurbuchen</li>
+          <li>Marc Jiang</li>
+          <li>Marco Wang</li>
+          <li>Melissa Escamilla Perez</li>
+          <li>Michael Chen</li>
+          <li>Mitchell Zhen</li>
+          <li>Naomi Wu</li>
+          <li>Nathan Summer Reiff</li>
+          <li>Nathaniel Hardy</li>
+          <li>Neil Vakharia</li>
+          <li>Nicole Tartakovsky</li>
+          <li>Priya Kini</li>
+          <li>Robert Bell</li>
+          <li>Saahas Parise</li>
+          <li>Sam Arrants</li>
+          <li>Sara Bouftas</li>
+          <li>Sebastian Perez</li>
+          <li>Sengdao Inthavong</li>
+          <li>Seth May</li>
+          <li>Shankar Salawan</li>
+          <li>Siddharth Sheth</li>
+          <li>Siddhartha Saha</li>
+          <li>Simeon Charles</li>
+          <li>Sophie Rollins</li>
+          <li>Stephenie Liew</li>
+          <li>Sydney Simmons</li>
+          <li>Timothy Fu</li>
+          <li>Timothy Mwiti</li>
+          <li>Tom Large</li>
+          <li>Tyler Nanoff</li>
+          <li>Vedant Apte</li>
+          <li><a href="https://www.visheshk.net/" target="_blank">Vishesh Kumar</a></li>
+          <li>Yamini Ulaganathan</li>
+          <li>Zoe Lewis</li>
+        </ul>
+      </div>
     </article>
   </main>
   

--- a/script.js
+++ b/script.js
@@ -26,11 +26,9 @@ function headerGenerator() {
             </li>
             <li>
                 <div class="btn-group">
-                    <button type="button" class="btn btn-primary">
-                        <a href=${rt + "projects/"} aria-label="Info on projects">projects
-                            <i class='uil uil-drill'></i>
-                        </a>
-                    </button>
+                    <a href=${rt + "projects/"} class="btn btn-primary" aria-label="Info on projects">projects
+                        <i class='uil uil-drill'></i>
+                    </a>
                     <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                       <span>▼</span>
                     </button>


### PR DESCRIPTION
## Summary
- Add Principal Investigator as section header
- Shorten names: Kidus Tessma, Victoria C. Chavez
- Reorganize alumni: group into PhD Alumni and Other Alumni, sort alphabetically
- Fix alumni HTML: wrap all entries in li tags, move links inside li
- Fix projects navbar: replace invalid button>a nesting with a.btn

## Files changed
- `people/index.html`
- `script.js`