### PR TITLE
Fix people page, projects page, and navbar styling

### DIFF
--- a/css/people.css
+++ b/css/people.css
@@ -14,22 +14,26 @@
   transform: rotate(-540deg);
 }
 .people .people-group {
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-content: flex-start;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
   gap: 2rem;
 }
 .people .people-group .textblock {
-  flex: 0 0 20rem;
   display: flex;
   flex-direction: column;
-  margin-bottom: 0;
 }
 .people .people-group .textblock h2 {
   border-bottom: solid 2px black;
   padding: 0.75rem;
+}
+.people .people-group .textblock .card-actions {
+  margin-top: auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+}
+.people .people-group .textblock .card-actions a:first-child:last-child {
+  margin-left: auto;
 }
 .people .people-group .top_dog h2 {
   border: 0;
@@ -39,19 +43,12 @@
   border-bottom: 2px solid black;
   font-size: 1.2rem;
 }
-.people article:not(.leaders) p {
-  -webkit-line-clamp: 60;
-  line-clamp: 60;
-}
 .people article:not(.leaders) p.contracted_text {
   -webkit-box-orient: vertical;
   display: -webkit-box;
-  -webkit-line-clamp: 8;
-  line-clamp: 60;
+  -webkit-line-clamp: 6;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: normal;
-  transition: line-clamp 5s linear;
 }
 .people .alumni h2 {
   font-size: 1.5rem;
@@ -59,8 +56,8 @@
   margin-bottom: 0.5rem;
 }
 .people .alumni ul {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));
+  display: flex;
+  flex-wrap: wrap;
   gap: 0.5rem;
 }
 .people .alumni ul li {
@@ -77,13 +74,14 @@
 .people .alumni ul li:has(a) a {
   display: block;
   padding: 0.5rem;
-  color: blue;
+  color: black;
   text-decoration: none;
 }
-.people img {
+.people .textblock img {
+  display: block;
   width: 100%;
-  aspect-ratio: 1 / 1;
-  height: 20rem;
+  height: auto;
+  aspect-ratio: 1/1;
   object-fit: cover;
   object-position: top;
   border-bottom: 2px solid #000;

--- a/css/styles.css
+++ b/css/styles.css
@@ -14,20 +14,26 @@
   transform: rotate(-540deg);
 }
 .people .people-group {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-evenly;
-  align-items: flex-start;
-  align-content: flex-start;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
+  gap: 2rem;
 }
 .people .people-group .textblock {
-  flex-basis: 20rem;
-  margin-bottom: 2rem;
+  display: flex;
+  flex-direction: column;
 }
 .people .people-group .textblock h2 {
   border-bottom: solid 2px black;
   padding: 0.75rem;
+}
+.people .people-group .textblock .card-actions {
+  margin-top: auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+}
+.people .people-group .textblock .card-actions a:first-child:last-child {
+  margin-left: auto;
 }
 .people .people-group .top_dog h2 {
   border: 0;
@@ -37,19 +43,12 @@
   border-bottom: 2px solid black;
   font-size: 1.2rem;
 }
-.people article:not(.leaders) p {
-  -webkit-line-clamp: 60;
-  line-clamp: 60;
-}
 .people article:not(.leaders) p.contracted_text {
   -webkit-box-orient: vertical;
   display: -webkit-box;
-  -webkit-line-clamp: 8;
-  line-clamp: 60;
+  -webkit-line-clamp: 6;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: normal;
-  transition: line-clamp 5s linear;
 }
 .people .alumni h2 {
   font-size: 1.5rem;
@@ -75,11 +74,16 @@
 .people .alumni ul li:has(a) a {
   display: block;
   padding: 0.5rem;
-  color: blue;
+  color: black;
   text-decoration: none;
 }
-.people img {
+.people .textblock img {
+  display: block;
   width: 100%;
+  height: auto;
+  aspect-ratio: 1/1;
+  object-fit: cover;
+  object-position: top;
   border-bottom: 2px solid #000;
   user-select: none;
 }
@@ -111,16 +115,9 @@
 }
 
 .projects {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: flex-start;
-  align-content: flex-start;
-  flex-wrap: wrap;
-}
-.projects h1 {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(30rem, 1fr));
+  gap: 1rem;
 }
 .projects h1 span {
   transform: rotate(0deg);
@@ -131,9 +128,11 @@
   transform: rotate(-540deg);
 }
 .projects .textblock {
-  margin-bottom: 1em;
-  flex-basis: 45rem;
   max-height: 90rem;
+}
+.projects .textblock h1 {
+  margin: 0;
+  padding-top: 0.25rem;
 }
 .projects img {
   width: 100%;
@@ -437,8 +436,8 @@ ul {
   list-style: none;
 }
 
-.people .people-group .textblock a,
-.people .people-group .textblock button, .papers .textblock .window__paper a, .classes .textblock span, .classes .textblock a {
+.people .people-group .textblock .card-actions button,
+.people .people-group .textblock .card-actions a, .projects .textblock .box, .papers .textblock .window__paper a, .classes .textblock span, .classes .textblock a {
   margin: 0.4rem;
   display: inline-block;
   border: 2px solid #000;
@@ -449,8 +448,8 @@ ul {
   color: black;
   transition: all 0.2s linear;
 }
-.people .people-group .textblock a:hover,
-.people .people-group .textblock button:hover, .papers .textblock .window__paper a:hover, .classes .textblock span:hover, .classes .textblock a:hover {
+.people .people-group .textblock .card-actions button:hover,
+.people .people-group .textblock .card-actions a:hover, .projects .textblock .box:hover, .papers .textblock .window__paper a:hover, .classes .textblock span:hover, .classes .textblock a:hover {
   color: white;
   background-color: black;
 }
@@ -519,6 +518,64 @@ header nav ul {
   justify-content: space-around;
   font-weight: bold;
   border: solid black 2px;
+}
+header nav ul .btn-group {
+  display: inline-flex;
+  flex-wrap: nowrap;
+  align-items: stretch;
+}
+header nav ul .btn-group > a.btn {
+  font-size: 1.5rem;
+  height: 5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+}
+header nav ul .btn-group > .dropdown-toggle {
+  display: flex;
+  align-items: center;
+  padding: 0 0.3rem;
+}
+header nav ul .btn {
+  padding: unset;
+  transition: none;
+}
+header nav ul .btn-primary,
+header nav ul .btn-primary:hover,
+header nav ul .btn-primary:focus,
+header nav ul .btn-primary:focus-visible,
+header nav ul .btn-primary:active,
+header nav ul .btn-primary:active:hover,
+header nav ul .btn-primary:active:focus,
+header nav ul .btn-primary:focus:hover,
+header nav ul .btn-primary.active,
+header nav ul .btn-primary.active:hover,
+header nav ul .btn-primary.active:focus,
+header nav ul .btn-primary.active.focus,
+header nav ul .btn-primary:active.focus,
+header nav ul .btn-primary.focus,
+header nav ul .open > .dropdown-toggle.btn-primary,
+header nav ul .open > .dropdown-toggle.btn-primary:focus,
+header nav ul .open > .dropdown-toggle.btn-primary:hover,
+header nav ul .open > .dropdown-toggle.btn-primary:focus:hover,
+header nav ul .open > .dropdown-toggle.btn-primary:active:hover,
+header nav ul .open > .dropdown-toggle.btn-primary.focus {
+  transition: none;
+  border-color: white;
+  background-color: white;
+  color: black;
+  outline: unset;
+  box-shadow: unset;
+}
+header nav ul .btn-primary a {
+  font-weight: bold;
+}
+header nav ul .dropdown-menu a {
+  height: auto;
+  display: block;
+  padding: 0.3rem 1rem;
+  font-size: 1.2rem;
 }
 header nav ul li a {
   transition: all 0.5s;

--- a/people/index.html
+++ b/people/index.html
@@ -23,12 +23,11 @@
 
   <main class="people">
     <article class="leaders" role="contentinfo" aria-label="Leaders of the lab">
+      <h1>Principal Investigator</h1>
       <div class="people-group">
-       
 
         <section class="textblock top_dog">
           <h2>Marcelo Worsley</h2>
-          <h3>Principal Investigator</h3>
           <img class="lazy" data-src="../assets/img/people/marcelo-worsley copy.jpg" alt="">
           <p>I am an associate professor of Learning Sciences and Computer Science at Northwestern's School of Education and Social Policy and the McCormick School of Engineering. My research aims to advance society's understanding of how students learn in complex learning environments by forging new opportunities for using multimodal technology.</p>
           <a href="http://marceloworsley.com/" target="_blank" rel="noreferrer" aria-label="Marcelo's Website">website</a>
@@ -117,7 +116,7 @@
         </section>
 
         <section class="textblock">
-          <h2>Victoria Concepción Chavez</h2>
+          <h2>Victoria C. Chavez</h2>
           <img class="lazy" data-src="../assets/img/people/victoria.jpg" alt="">
           <p>Victoria (V/they/she) is a Chicago-born and raised Chapine (Guatemalan) educator, scholar, and engineer. Currently, they’re a third-year PhD student at Northwestern University's Computer Science Program. Victoria’s research interests explore systemic issues within computer science education, centering the experiences of Black, Disabled, Indigenous, and Latine/x students. Most recently, their research has focused on teaching and learning accessibility as well as unpacking how ableism is codified in the policies, practices, and pedagogies used in college CS courses.</p>
           <a href="https://vickiebananas.com/" target="_blank">website</a>
@@ -127,7 +126,6 @@
           <h2>Meg Butler</h2>
           <img class="lazy" data-src="../assets/img/people/meg-butler-hotdog.jpg" alt="Meg Butler Hotdog">
           <p>As a disabled researcher and educator, Meg is particularly interested in educational dignity. Her work seeks to challenge the deficit-based views of human learning that are complicit in the reification of normatively powered dynamics and push beyond the practices that maintain and enact ableism to a dynamic coexistence of multiple ways of seeing and knowing. She enjoys riding her bike, hanging out with animals, and eating Albanese gummy bears.</p>
-          </p>
         </section>
 
         <section class="textblock">
@@ -149,7 +147,7 @@
       <div class="people-group">
 
         <section class="textblock">
-          <h2>Kidus Chernet Tessma</h2>
+          <h2>Kidus Tessma</h2>
           <img class="lazy" data-src="../assets/img/people/kidus-tessma.jpg" alt="">
           <p>Kidus Chernet Tessma is a junior studying Computer Science and Mathematics. I am working on the SportSense Team in redesigning the FAAM website.</p>
           <!-- <a href="#" target="_blank">website</a> -->
@@ -269,90 +267,91 @@
           <li>Kit Martin</li>
           <li>JaCoya Thompson</li>
           <li>Emily Q. Wang</li>
+
         </ul>
       </div>
 
       <h2>Other Alumni</h2>
       <div class="list-group">
         <ul>
-          <li>Aaron Karp</li>
-          <li><a href="https://sites.northwestern.edu/adiawallace/" target="_blank">Adia Wallace</a></li>
-          <li><a href="https://www.afreenbhumgara.me/" target="_blank">Afreen Bhumgara</a></li>
-          <li>Aimee van der Berg</li>
-          <li>Alex Gist</li>
-          <li>Alexander Redding</li>
-          <li>Andy Ko</li>
-          <li>Andy Moran</li>
-          <li>Antonio Rocha</li>
-          <li>Aryan Mahajan</li>
-          <li>Audrey DeBruine</li>
-          <li>Avi Vaid</li>
-          <li>Beck Mallwitz</li>
-          <li>Bobbie Burgess</li>
-          <li>Caroline DeMarco</li>
-          <li>Danny Pineda</li>
-          <li>Deniz Sagnalakar</li>
-          <li>Durell Gill</li>
-          <li>Edward Kang</li>
-          <li>Elana Stettin</li>
-          <li>Emily Blackman</li>
-          <li>Eric Mertz</li>
-          <li>Ethan M. Chan</li>
-          <li><a href="https://ethanpinedaa.dev/" target="_blank">Ethan Piñeda</a></li>
-          <li>Gabe Rojas-Westall</li>
-          <li>Haley De Boom</li>
-          <li>Harrison Pearl</li>
-          <li>Jaiveer Kothari</li>
-          <li>Jeremy Libretti-River</li>
-          <li>Jimmy Song</li>
-          <li>John Sanchez</li>
-          <li>JooYoung Jang</li>
-          <li>Joonyong Rhee</li>
-          <li>Jordan Nishina</li>
-          <li>Joy Hsu</li>
-          <li>Judy Lee</li>
-          <li>Julie Park</li>
-          <li><a href="https://www.linkedin.com/in/justin-aronson/" target="_blank">Justin Aronson</a></li>
-          <li>Justin Jia</li>
-          <li>Kelia Human</li>
-          <li>Kevin Mendoza</li>
-          <li>Kira Furuichi</li>
-          <li>Kya Suzuki</li>
-          <li>Lindsay Rawitscher</li>
-          <li>Lucas Zurbuchen</li>
-          <li>Marc Jiang</li>
-          <li>Marco Wang</li>
-          <li>Melissa Escamilla Perez</li>
-          <li>Michael Chen</li>
-          <li>Mitchell Zhen</li>
-          <li>Naomi Wu</li>
-          <li>Nathan Summer Reiff</li>
-          <li>Nathaniel Hardy</li>
-          <li>Neil Vakharia</li>
-          <li>Nicole Tartakovsky</li>
-          <li>Priya Kini</li>
-          <li>Robert Bell</li>
-          <li>Saahas Parise</li>
-          <li>Sam Arrants</li>
-          <li>Sara Bouftas</li>
-          <li>Sebastian Perez</li>
-          <li>Sengdao Inthavong</li>
-          <li>Seth May</li>
-          <li>Shankar Salawan</li>
-          <li>Siddharth Sheth</li>
-          <li>Siddhartha Saha</li>
-          <li>Simeon Charles</li>
-          <li>Sophie Rollins</li>
-          <li>Stephenie Liew</li>
-          <li>Sydney Simmons</li>
-          <li>Timothy Fu</li>
-          <li>Timothy Mwiti</li>
-          <li>Tom Large</li>
-          <li>Tyler Nanoff</li>
           <li>Vedant Apte</li>
+          <li><a href="https://www.linkedin.com/in/justin-aronson/" target="_blank">Justin Aronson</a></li>
+          <li>Sam Arrants</li>
+          <li>Robert Bell</li>
+          <li><a href="https://www.afreenbhumgara.me/" target="_blank">Afreen Bhumgara</a></li>
+          <li>Emily Blackman</li>
+          <li>Sara Bouftas</li>
+          <li>Bobbie Burgess</li>
+          <li>Ethan M. Chan</li>
+          <li>Simeon Charles</li>
+          <li>Michael Chen</li>
+          <li>Haley De Boom</li>
+          <li>Audrey DeBruine</li>
+          <li>Caroline DeMarco</li>
+          <li>Melissa Escamilla Perez</li>
+          <li>Timothy Fu</li>
+          <li>Kira Furuichi</li>
+          <li>Durell Gill</li>
+          <li>Alex Gist</li>
+          <li>Nathaniel Hardy</li>
+          <li>Joy Hsu</li>
+          <li>Kelia Human</li>
+          <li>Sengdao Inthavong</li>
+          <li>JooYoung Jang</li>
+          <li>Justin Jia</li>
+          <li>Marc Jiang</li>
+          <li>Edward Kang</li>
+          <li>Aaron Karp</li>
+          <li>Priya Kini</li>
+          <li>Andy Ko</li>
+          <li>Jaiveer Kothari</li>
           <li><a href="https://www.visheshk.net/" target="_blank">Vishesh Kumar</a></li>
-          <li>Yamini Ulaganathan</li>
+          <li>Tom Large</li>
+          <li>Judy Lee</li>
           <li>Zoe Lewis</li>
+          <li>Stephenie Liew</li>
+          <li>Jeremy Libretti-River</li>
+          <li>Aryan Mahajan</li>
+          <li>Beck Mallwitz</li>
+          <li>Seth May</li>
+          <li>Kevin Mendoza</li>
+          <li>Eric Mertz</li>
+          <li>Andy Moran</li>
+          <li>Timothy Mwiti</li>
+          <li>Tyler Nanoff</li>
+          <li>Jordan Nishina</li>
+          <li>Saahas Parise</li>
+          <li>Julie Park</li>
+          <li>Harrison Pearl</li>
+          <li>Sebastian Perez</li>
+          <li>Danny Pineda</li>
+          <li><a href="https://ethanpinedaa.dev/" target="_blank">Ethan Piñeda</a></li>
+          <li>Lindsay Rawitscher</li>
+          <li>Alexander Redding</li>
+          <li>Nathan Summer Reiff</li>
+          <li>Joonyong Rhee</li>
+          <li>Antonio Rocha</li>
+          <li>Gabe Rojas-Westall</li>
+          <li>Sophie Rollins</li>
+          <li>Deniz Sagnalakar</li>
+          <li>Siddhartha Saha</li>
+          <li>Shankar Salawan</li>
+          <li>John Sanchez</li>
+          <li>Siddharth Sheth</li>
+          <li>Sydney Simmons</li>
+          <li>Jimmy Song</li>
+          <li>Elana Stettin</li>
+          <li>Kya Suzuki</li>
+          <li>Nicole Tartakovsky</li>
+          <li>Yamini Ulaganathan</li>
+          <li>Neil Vakharia</li>
+          <li>Aimee van der Berg</li>
+          <li>Avi Vaid</li>
+          <li><a href="https://sites.northwestern.edu/adiawallace/" target="_blank">Adia Wallace</a></li>
+          <li>Marco Wang</li>
+          <li>Naomi Wu</li>
+          <li>Mitchell Zhen</li>
+          <li>Lucas Zurbuchen</li>
         </ul>
       </div>
     </article>

--- a/script.js
+++ b/script.js
@@ -26,11 +26,9 @@ function headerGenerator() {
             </li>
             <li>
                 <div class="btn-group">
-                    <button type="button" class="btn btn-primary">
-                        <a href=${rt + "projects/"} aria-label="Info on projects">projects
-                            <i class='uil uil-drill'></i>
-                        </a>
-                    </button>
+                    <a href=${rt + "projects/"} class="btn btn-primary" aria-label="Info on projects">projects
+                        <i class='uil uil-drill'></i>
+                    </a>
                     <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                       <span>▼</span>
                     </button>
@@ -141,7 +139,7 @@ function subset(l1, l2) {
 }
 
 function contractText(e) {
-    const p_Sibling = e.parentElement.querySelector('p');
+    const p_Sibling = e.closest('.textblock').querySelector('p');
 
     const textContracted = p_Sibling.classList.toggle("contracted_text");
     if (textContracted) {
@@ -153,18 +151,40 @@ function contractText(e) {
 
 function addReadMoreButtons() {
     const paragraphs = document.querySelectorAll("article:not(.leaders) > .people-group section p");
-    const paragraphArr = Array.from(paragraphs);
-    const filtered = paragraphArr.filter(para => para.clientHeight > 200);
 
-    filtered.map((bigPara) => {
-        bigPara.classList.add('contracted_text');
+    // Apply clamp to all paragraphs first
+    paragraphs.forEach((para) => {
+        para.classList.add('contracted_text');
+    });
 
-        const button = document.createElement("button");
-        const newContent = document.createTextNode("read more");
-        button.appendChild(newContent);
-        button.addEventListener('click', () => contractText(button));
+    // Wait for reflow, then check which are truncated
+    requestAnimationFrame(() => {
+        paragraphs.forEach((para) => {
+            if (para.scrollHeight > para.clientHeight) {
+                const button = document.createElement("button");
+                button.textContent = "read more";
+                button.addEventListener('click', () => contractText(button));
+                para.after(button);
+            }
+        });
+        wrapCardFooters();
+    });
+}
 
-        bigPara.after(button);
+function wrapCardFooters() {
+    const cards = document.querySelectorAll(".people-group .textblock");
+    cards.forEach(card => {
+        const footer = document.createElement("div");
+        footer.classList.add("card-actions");
+
+        const buttons = card.querySelectorAll(":scope > button");
+        const links = card.querySelectorAll(":scope > a");
+
+        if (buttons.length === 0 && links.length === 0) return;
+
+        buttons.forEach(btn => footer.appendChild(btn));
+        links.forEach(link => footer.appendChild(link));
+        card.appendChild(footer);
     });
 }
 

--- a/scss/people.scss
+++ b/scss/people.scss
@@ -19,29 +19,34 @@
   }
 
   .people-group {
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-content: flex-start;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
     gap: 2rem;
 
     .textblock {
-      flex: 0 0 20rem;
       display: flex;
       flex-direction: column;
-      margin-bottom: 0;
 
       h2 {
         border-bottom: solid 2px black;
         padding: 0.75rem;
       }
 
-      p {}
+      .card-actions {
+        margin-top: auto;
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-end;
 
-      a,
-      button {
-        @extend %squared_button  !optional;
+        button,
+        a {
+          @extend %squared_button !optional;
+        }
+
+        // When there's no button, push lone link to the right
+        a:first-child:last-child {
+          margin-left: auto;
+        }
       }
     }
 
@@ -60,22 +65,14 @@
 
   article:not(.leaders) {
     p {
-      -webkit-line-clamp: 60;
-      line-clamp: 60;
       &.contracted_text {
         -webkit-box-orient: vertical;
         display: -webkit-box;
-        -webkit-line-clamp: 8;
-        line-clamp: 60;
-
+        -webkit-line-clamp: 6;
         overflow: hidden;
         text-overflow: ellipsis;
-        white-space: normal;
-        transition: line-clamp 5s linear;
       }
-
     }
-
   }
 
   .alumni {
@@ -105,17 +102,18 @@
         a {
           display: block;
           padding: .5rem;
-          color: blue;
+          color: black;
           text-decoration: none;
         }
       }
     }
   }
 
-  img {
+  .textblock img {
+    display: block;
     width: 100%;
+    height: auto;
     aspect-ratio: 1 / 1;
-    height: 20rem;
     object-fit: cover;
     object-position: top;
     border-bottom: 2px solid #000;

--- a/scss/projects.scss
+++ b/scss/projects.scss
@@ -1,15 +1,9 @@
 .projects {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: flex-start;
-    align-content: flex-start;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(30rem, 1fr));
+    gap: 1rem;
 
-    // outline: solid rosybrown 1px;
     h1 {
-      display: flex;
-      justify-content: space-between;
       span {
         transform: rotate(0deg);
         transition-delay: 50ms;
@@ -20,9 +14,16 @@
       }
     }
     .textblock {
-      margin-bottom: 1em;
-      flex-basis: 45rem;
       max-height: 90rem;
+
+      h1 {
+        margin: 0;
+        padding-top: 0.25rem;
+      }
+
+      .box {
+        @extend %squared_button !optional;
+      }
     }
     img {
       width: 100%;

--- a/scss/styles.scss
+++ b/scss/styles.scss
@@ -154,6 +154,71 @@ header {
       font-weight: bold;
       border: solid black 2px;
 
+      .btn-group {
+        display: inline-flex;
+        flex-wrap: nowrap;
+        align-items: stretch;
+
+        > a.btn {
+          font-size: 1.5rem;
+          height: 5rem;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-weight: bold;
+        }
+
+        > .dropdown-toggle {
+          display: flex;
+          align-items: center;
+          padding: 0 0.3rem;
+        }
+      }
+
+      .btn {
+        padding: unset;
+        transition: none;
+      }
+
+      .btn-primary,
+      .btn-primary:hover,
+      .btn-primary:focus,
+      .btn-primary:focus-visible,
+      .btn-primary:active,
+      .btn-primary:active:hover,
+      .btn-primary:active:focus,
+      .btn-primary:focus:hover,
+      .btn-primary.active,
+      .btn-primary.active:hover,
+      .btn-primary.active:focus,
+      .btn-primary.active.focus,
+      .btn-primary:active.focus,
+      .btn-primary.focus,
+      .open > .dropdown-toggle.btn-primary,
+      .open > .dropdown-toggle.btn-primary:focus,
+      .open > .dropdown-toggle.btn-primary:hover,
+      .open > .dropdown-toggle.btn-primary:focus:hover,
+      .open > .dropdown-toggle.btn-primary:active:hover,
+      .open > .dropdown-toggle.btn-primary.focus {
+        transition: none;
+        border-color: white;
+        background-color: white;
+        color: black;
+        outline: unset;
+        box-shadow: unset;
+      }
+
+      .btn-primary a {
+        font-weight: bold;
+      }
+
+      .dropdown-menu a {
+        height: auto;
+        display: block;
+        padding: 0.3rem 1rem;
+        font-size: 1.2rem;
+      }
+
       li {
         a {
           transition: all 0.5s;


### PR DESCRIPTION
## Summary
- **People cards**: CSS grid layout with uniform square images, flex-column cards with `.card-actions` footer pinned to bottom, 6-line text clamp with dynamic "read more" buttons, lone website links pushed right
- **Projects page**: CSS grid layout, bordered link boxes via `%squared_button`, reduced title top padding
- **Navbar**: Replaced invalid `<button><a>` nesting with `<a class="btn btn-primary">`, added btn-group/btn-primary styles to SCSS source so they survive compilation
- **Alumni section**: Black text on blue-bordered linked items
- **HTML fixes**: Removed stray `</p>` (Meg Butler), fixed `<secton>` typos (Milind/Joshua), shortened names (Kidus Tessma, Victoria C. Chavez), moved "Principal Investigator" to section header