### PR TITLE
Fix projects page layout and subpage image sizing

### DIFF
--- a/css/projects.css
+++ b/css/projects.css
@@ -1,14 +1,7 @@
 .projects {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: flex-start;
-  align-content: flex-start;
-  flex-wrap: wrap;
-}
-.projects h1 {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
 }
 .projects h1 span {
   transform: rotate(0deg);
@@ -19,9 +12,19 @@
   transform: rotate(-540deg);
 }
 .projects .textblock {
-  margin-bottom: 1em;
-  flex-basis: 45rem;
+  display: flex;
+  flex-direction: column;
   max-height: 90rem;
+}
+.projects .textblock h1 {
+  margin: 0;
+  padding-top: 0.25rem;
+}
+.projects .textblock .card-actions {
+  margin-top: auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
 }
 .projects img {
   width: 100%;
@@ -29,5 +32,28 @@
   max-height: 100rem;
   transition: max-height 1s linear;
   overflow: hidden;
-  border-bottom: #000 2px solid;
-} /*# sourceMappingURL=projects.css.map */
+  border-bottom: black 2px solid;
+}
+
+.projectpages img {
+  max-width: 100%;
+  height: auto;
+}
+.projectpages .pictures {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  gap: 1rem;
+}
+.projectpages .pictures img {
+  width: 100%;
+  object-fit: cover;
+}
+.projectpages iframe {
+  max-width: 100%;
+}
+
+@media only screen and (max-width: 640px) {
+  .projects {
+    grid-template-columns: 1fr;
+  }
+}

--- a/css/styles.css
+++ b/css/styles.css
@@ -116,7 +116,7 @@
 
 .projects {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(30rem, 1fr));
+  grid-template-columns: repeat(2, 1fr);
   gap: 1rem;
 }
 .projects h1 span {
@@ -128,11 +128,19 @@
   transform: rotate(-540deg);
 }
 .projects .textblock {
+  display: flex;
+  flex-direction: column;
   max-height: 90rem;
 }
 .projects .textblock h1 {
   margin: 0;
   padding-top: 0.25rem;
+}
+.projects .textblock .card-actions {
+  margin-top: auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
 }
 .projects img {
   width: 100%;
@@ -143,6 +151,28 @@
   border-bottom: black 2px solid;
 }
 
+.projectpages img {
+  max-width: 100%;
+  height: auto;
+}
+.projectpages .pictures {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  gap: 1rem;
+}
+.projectpages .pictures img {
+  width: 100%;
+  object-fit: cover;
+}
+.projectpages iframe {
+  max-width: 100%;
+}
+
+@media only screen and (max-width: 640px) {
+  .projects {
+    grid-template-columns: 1fr;
+  }
+}
 .papers {
   display: flex;
   flex-direction: column;
@@ -437,7 +467,7 @@ ul {
 }
 
 .people .people-group .textblock .card-actions button,
-.people .people-group .textblock .card-actions a, .projects .textblock .box, .papers .textblock .window__paper a, .classes .textblock span, .classes .textblock a {
+.people .people-group .textblock .card-actions a, .projects .textblock .card-actions a, .papers .textblock .window__paper a, .classes .textblock span, .classes .textblock a {
   margin: 0.4rem;
   display: inline-block;
   border: 2px solid #000;
@@ -449,7 +479,7 @@ ul {
   transition: all 0.2s linear;
 }
 .people .people-group .textblock .card-actions button:hover,
-.people .people-group .textblock .card-actions a:hover, .projects .textblock .box:hover, .papers .textblock .window__paper a:hover, .classes .textblock span:hover, .classes .textblock a:hover {
+.people .people-group .textblock .card-actions a:hover, .projects .textblock .card-actions a:hover, .papers .textblock .window__paper a:hover, .classes .textblock span:hover, .classes .textblock a:hover {
   color: white;
   background-color: black;
 }

--- a/projects/index.html
+++ b/projects/index.html
@@ -32,22 +32,30 @@
         where youth are introduced to ways that technology can help them improve their athletic performance,
         and ways that sports can improve their understanding of STEM concepts.
       </p>
-      <a class="box" href="./sportsense/index.html">learn more</a> <a class="box" href="https://www.blackkidspredict.org">BKP Sports</a>
+      <div class="card-actions">
+        <a href="./sportsense/index.html">learn more</a>
+        <a href="https://www.blackkidspredict.org">BKP Sports</a>
+      </div>
     </section>
     <section class="textblock project_box">
       <h1>Blinc</h1>
       <p class="window__description">This team works on developing data-capture devices
         that provide educators with real-time multimodal learning analytics. We use ReSpeaker Core v2.0 microphone arrays to show educators what keywords have been said, a discussion timeline, direction of speech, and emotional tone indicators. We are also working to incorporate body pose estimation into our analyses. We have tested our devices in multiple classrooms and are continuing development and testing in the coming months.
       </p>
-      <a class="box" href="./blinc/index.html">learn more</a>
+      <div class="card-actions">
+        <a href="./blinc/index.html">learn more</a>
+      </div>
     </section>
     <section class="textblock project_box">
-      <h1>SportSense for Data Literacy</h1>
-      <p class="window__description">
-        SportSense for Data Literacy is an 8 week sports and data curriculum for fifth-grade students. The intention of this curriculum is to support students in learning and practicing data processes via their personal physical movement. The overarching framework used throughout the curriculum was a four-stage data process that was introduced to students at the start of the unit. Lessons use the Play Impossible Gameball, micro:bit, and Scratch. Below you can find the lesson plans and materials for each week.
-      </p>
-      <a class="box" href="./sportsensefordata/index.html">learn more</a> <a class="box" href="https://docs.google.com/document/d/1aku6Bz6hKWT9OaoNX-y0WtMKkF6DQgNLg3iSTDYePz4/edit?tab=t.0">SportSense Overview</a>
-    </section>
+      <h1>SportSense for Data Literacy</h1>
+      <p class="window__description">
+        SportSense for Data Literacy is an 8 week sports and data curriculum for fifth-grade students. The intention of this curriculum is to support students in learning and practicing data processes via their personal physical movement. The overarching framework used throughout the curriculum was a four-stage data process that was introduced to students at the start of the unit. Lessons use the Play Impossible Gameball, micro:bit, and Scratch. Below you can find the lesson plans and materials for each week.
+      </p>
+      <div class="card-actions">
+        <a href="./sportsensefordata/index.html">learn more</a>
+        <a href="https://docs.google.com/document/d/1aku6Bz6hKWT9OaoNX-y0WtMKkF6DQgNLg3iSTDYePz4/edit?tab=t.0">SportSense Overview</a>
+      </div>
+    </section>
     
      <section class="textblock project_box">
       <h1>Learning with Minecraft</h1>
@@ -55,7 +63,9 @@
         <b>Learning with Minecraft</b> studies how children might learn spatial reasoning and programming skills within and around the game. We are currently conducting a comparative study of student collaboration under two conditions:
         1) Completing a construction task in a traditional Minecraft server; and 2) Using the MakeCode interface in Minecraft Education Edition. Additionally, we are using screen capture and eye tracking technologies to collect data and investigate spatial reasoning processes in Minecraft gameplay.
       </p>
-      <a class="box" href="./minecraft/index.html">learn more</a>
+      <div class="card-actions">
+        <a href="./minecraft/index.html">learn more</a>
+      </div>
     </section>
 
     <section class="textblock project_box">
@@ -63,7 +73,9 @@
       <p class="window__description"><b>Multicraft + Tangicraft</b> works on multimodal interfaces to empower
         individuals with physical impairments to play and create in the popular video game Minecraft. Multicraft utilizes Gaze and Speech to replace the traditional mouse and keyboard interface. By looking at a location on the screen and uttering a command, users can build in the Minecraft world. Tangicraft utilizes tangible blocks with webcam detectable codes. Users can construct a physical structure in front of a webcam and call it in the Minecraft world by pressing a button on an Arduino microcontroller. Our team is currently conducting user tests to drive iteration on our initial designs.
       </p>
-      <a class="box" href="./multicraft/index.html">learn more</a>
+      <div class="card-actions">
+        <a href="./multicraft/index.html">learn more</a>
+      </div>
     </section>
         <section class="textblock project_box">
       <h1>Global Aid Refugees (GAR)</h1>
@@ -87,7 +99,9 @@
       <h1>IMR (Imagine, Make, Repeat)</h1>
       <p class="window__description"><b>IMR (Imagine, Make, Repeat)</b> works with educators to plan and implement Makerspace technologies and projects in classrooms and Makerspaces throughout Evanston and Chicago. IMR has appeared at STEMFest, YEA! festival, and has collaborated with Chute Middle School, MetaMedia at the Evanston YMCA, and the Evanston Public Library. Going forward, the IMR team looks to further develop and expand partnerships with educators and making communities across the Chicagoland area.
       </p>
-      <a class="box" href="./imr/index.html">learn more</a>
+      <div class="card-actions">
+        <a href="./imr/index.html">learn more</a>
+      </div>
     </section>
     <section class="textblock project_box">
       <h1>FamJam!</h1>
@@ -95,7 +109,9 @@
       <p class="window__description">
         <b>FamJam!</b> engages children and their families in a making, learning, and bonding experience. Over three sessions, families use low- and high-tech tools to create a game based on a family narrative or story. We seek to understand how we can meaningfully engage families in “making” activities both in facilitated makerspaces and at home.
       </p>
-      <a class="box" href="./famjam/index.html">learn more</a>
+      <div class="card-actions">
+        <a href="./famjam/index.html">learn more</a>
+      </div>
     </section>
     
     <section class="textblock project_box">

--- a/scss/projects.scss
+++ b/scss/projects.scss
@@ -1,6 +1,6 @@
 .projects {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(30rem, 1fr));
+    grid-template-columns: repeat(2, 1fr);
     gap: 1rem;
 
     h1 {
@@ -14,6 +14,8 @@
       }
     }
     .textblock {
+      display: flex;
+      flex-direction: column;
       max-height: 90rem;
 
       h1 {
@@ -21,8 +23,15 @@
         padding-top: 0.25rem;
       }
 
-      .box {
-        @extend %squared_button !optional;
+      .card-actions {
+        margin-top: auto;
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-end;
+
+        a {
+          @extend %squared_button !optional;
+        }
       }
     }
     img {
@@ -33,4 +42,32 @@
       overflow: hidden;
       border-bottom: black 2px solid;
     }
+}
+
+.projectpages {
+    img {
+      max-width: 100%;
+      height: auto;
+    }
+
+    .pictures {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+      gap: 1rem;
+
+      img {
+        width: 100%;
+        object-fit: cover;
+      }
+    }
+
+    iframe {
+      max-width: 100%;
+    }
+}
+
+@media only screen and (max-width: 640px) {
+  .projects {
+    grid-template-columns: 1fr;
+  }
 }


### PR DESCRIPTION
## Summary
- Display exactly 2 project cards per row using CSS grid
- Position "learn more" buttons at bottom-left of cards, with secondary links (BKP Sports, SportSense Overview) at bottom-right
- Fix non-breaking space formatting issue in SportSense for Data Literacy card
- Constrain images and iframes on project subpages to fit within their containers
- Add responsive grid layout for picture galleries on subpages (blinc, multicraft, famjam, imr)

## Test plan
- [x] Verify projects page shows 2 cards per row on desktop
- [x] Verify buttons are positioned at bottom of cards (learn more left, secondary links right)
- [x] Verify SportSense for Data Literacy card has no extra whitespace
- [x] Check project subpages (e.g. /projects/blinc/) for properly sized images
- [x] Verify mobile layout falls back to single column