### PR TITLE
Fix navbar projects button shifting when active

### DIFF
--- a/script.js
+++ b/script.js
@@ -76,7 +76,7 @@ function headerGenerator() {
     var links = Array.from(document.getElementsByTagName("a"))
     curr_page = curr_page.split("/").filter(i => i != "")
     links = links.filter(l => window.location.href == l.href || subset(l.href.slice(l.href.indexOf("edu") + 3).split("/").filter(i => i != ""), curr_page)) 
-    links.forEach(l => l.setAttribute("class", "current-page"))
+    links.forEach(l => l.classList.add("current-page"))
 }
 
 function wide() { 


### PR DESCRIPTION
Use classList.add instead of setAttribute to preserve existing Bootstrap btn classes when adding the current-page indicator.