### PR TITLE
Add subtle fade-in animation for content cards on all pages

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -636,6 +636,11 @@ main .textblock {
   border: solid 2px black;
   transition: box-shadow 0.2s linear;
   background-color: #ffffff;
+  opacity: 0;
+  transform: translateY(1rem);
+}
+main .textblock.visible {
+  animation: card-enter 0.4s ease forwards;
 }
 main .textblock:hover {
   box-shadow: 4px 5px;
@@ -689,4 +694,22 @@ main.about .textblock {
   margin-left: auto;
   position: relative;
   z-index: 99;
+}
+
+@keyframes card-enter {
+  from {
+    opacity: 0;
+    transform: translateY(1rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  main .textblock {
+    opacity: 1;
+    transform: none;
+    animation: none !important;
+  }
 }

--- a/script.js
+++ b/script.js
@@ -279,7 +279,26 @@ window.onload = () => {
         }
     }
 
-    const myLazyLoad = new LazyLoad({
-        elements_selector: ".lazy"
-    });
+    if (typeof LazyLoad !== 'undefined') {
+        const myLazyLoad = new LazyLoad({
+            elements_selector: ".lazy"
+        });
+    }
+
+    // Animate textblocks into view with staggered delays
+    var cards = document.querySelectorAll('.textblock');
+    if (cards.length > 0 && 'IntersectionObserver' in window) {
+        var observer = new IntersectionObserver(function(entries) {
+            entries.forEach(function(entry) {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add('visible');
+                    observer.unobserve(entry.target);
+                }
+            });
+        }, { threshold: 0.1 });
+        cards.forEach(function(card) { observer.observe(card); });
+    } else {
+        // Fallback: show all immediately
+        cards.forEach(function(card) { card.classList.add('visible'); });
+    }
 };

--- a/scss/styles.scss
+++ b/scss/styles.scss
@@ -257,6 +257,13 @@ main {
     border: solid 2px black;
     transition: box-shadow 0.2s linear;
     background-color: #ffffff;
+    opacity: 0;
+    transform: translateY(1rem);
+
+    &.visible {
+      animation: card-enter 0.4s ease forwards;
+    }
+
     &:hover {
       box-shadow: 4px 5px;
     }
@@ -310,7 +317,7 @@ main {
     ol {
       margin: 0.75rem;
     }
-  
+
     .textblock {
       max-width: 55rem;
       margin-bottom: 1vh;
@@ -318,6 +325,25 @@ main {
       position: relative;
       z-index: 99;
     }
+  }
+}
+
+@keyframes card-enter {
+  from {
+    opacity: 0;
+    transform: translateY(1rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  main .textblock {
+    opacity: 1;
+    transform: none;
+    animation: none !important;
   }
 }
 


### PR DESCRIPTION
Cards start hidden and slide up as they enter the viewport using IntersectionObserver. Guard LazyLoad call so it doesn't crash on pages that don't include the library (classes, papers). Respects prefers-reduced-motion for accessibility.