### PR TITLE
Remove Marcelo's website link from people page

### DIFF
--- a/people/index.html
+++ b/people/index.html
@@ -30,7 +30,6 @@
           <h2>Marcelo Worsley</h2>
           <img class="lazy" data-src="../assets/img/people/marcelo-worsley copy.jpg" alt="">
           <p>I am an associate professor of Learning Sciences and Computer Science at Northwestern's School of Education and Social Policy and the McCormick School of Engineering. My research aims to advance society's understanding of how students learn in complex learning environments by forging new opportunities for using multimodal technology.</p>
-          <a href="http://marceloworsley.com/" target="_blank" rel="noreferrer" aria-label="Marcelo's Website">website</a>
         </section>
 
 


### PR DESCRIPTION
## Summary
- Remove the website link from Marcelo Worsley's card on the people page

## Test plan
- [ ] Verify Marcelo's card no longer shows a website button
- [ ] Verify other cards still show website and read more buttons correctly aligned