### PR TITLE
Fix website button styling on people page

### DIFF
--- a/script.js
+++ b/script.js
@@ -274,6 +274,7 @@ window.onload = () => {
     if (location.href.includes("people")) {
         if (navigator.userAgent.indexOf("Firefox") !== -1) {
             console.log('lol @ Firefox');
+            wrapCardFooters();
         } else {
             addReadMoreButtons();
         }


### PR DESCRIPTION
Call wrapCardFooters() on Firefox where addReadMoreButtons() is skipped, so website links still get wrapped in .card-actions and receive the squared button styling.