### PR TITLE
Fix mobile nav: projects text size and dropdown arrow color

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -513,6 +513,12 @@ ul {
   body header nav ul li .current-page {
     text-decoration: none;
   }
+  body header nav ul .btn-group > a.btn {
+    font-size: 1rem;
+  }
+  body header nav ul .btn-group > .dropdown-toggle span {
+    color: black;
+  }
   body main {
     margin: 0 1.2rem 2rem;
   }
@@ -713,3 +719,5 @@ main.about .textblock {
     animation: none !important;
   }
 }
+
+/*# sourceMappingURL=styles.css.map */

--- a/scss/styles.scss
+++ b/scss/styles.scss
@@ -104,6 +104,18 @@ ul {
               text-decoration: none;
             }
           }
+
+          .btn-group {
+            > a.btn {
+              font-size: 1rem;
+            }
+
+            > .dropdown-toggle {
+              span {
+                color: black;
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
- Override .btn-group > a.btn font-size to 1rem on mobile to match other nav items
- Force dropdown toggle arrow to black on mobile (was inheriting Bootstrap blue)