### PR TITLE
Remove netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,0 @@
-[build]
-  command = "echo 'skip build'"
-  publish = "/"


### PR DESCRIPTION
## Summary
- Deletes `netlify.toml` since the CMS backend has been migrated to a self-hosted GitHub OAuth proxy on glamdring

## Test plan
- [ ] Verify site still builds and serves correctly on GitHub Pages
- [ ] Verify CMS login at `/admin/` still works via GitHub OAuth